### PR TITLE
updating function runtime to nodejs20

### DIFF
--- a/.github/workflows/pubsub-smoke.yml
+++ b/.github/workflows/pubsub-smoke.yml
@@ -1,0 +1,32 @@
+name: pubsub smoke
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/pubsub-smoke.yml"
+      - "examples/pubsub/**"
+      - "modules/pubsub/**"
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/pubsub-smoke.yml"
+      - "examples/pubsub/**"
+      - "modules/pubsub/**"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform init
+        run: terraform -chdir=examples/pubsub init -backend=false
+
+      - name: Terraform validate
+        run: terraform -chdir=examples/pubsub validate

--- a/modules/pubsub/main.tf
+++ b/modules/pubsub/main.tf
@@ -44,7 +44,7 @@ resource "google_storage_bucket_object" "this" {
 resource "google_cloudfunctions_function" "this" {
   name                  = local.function_name
   description           = "Send PubSub logs to Coralogix."
-  runtime               = "nodejs14"
+  runtime               = "nodejs20"
   available_memory_mb   = 1024
   timeout               = 60
   source_archive_bucket = google_storage_bucket_object.this.bucket

--- a/modules/pubsub/main.tf
+++ b/modules/pubsub/main.tf
@@ -44,7 +44,7 @@ resource "google_storage_bucket_object" "this" {
 resource "google_cloudfunctions_function" "this" {
   name                  = local.function_name
   description           = "Send PubSub logs to Coralogix."
-  runtime               = "nodejs14"
+  runtime               = "nodejs22"
   available_memory_mb   = 1024
   timeout               = 60
   source_archive_bucket = google_storage_bucket_object.this.bucket

--- a/modules/pubsub/src/package.json
+++ b/modules/pubsub/src/package.json
@@ -12,7 +12,7 @@
     "url": "https://coralogix.com"
   },
   "engines": {
-    "node": "14.x"
+    "node": "22.x"
   },
   "contributors": [
     {


### PR DESCRIPTION
nodejs14 was deprecated from supported runtimes in cloudfunctions, this pr changes default runtime to nodejs20

error that i was hitting before is 
```╷
│ Error: googleapi: Error 400: Failed to create 1st Gen function projects/REDACTED/locations/us-central1/functions/Coralogix-PubSub-oyP4Gq0fvTX1: runtime: Runtime validation errors: [error_code: DEPLOYS_NOT_ALLOWED
│ message: "Runtime nodejs14 is decommissioned and no longer allowed. Please use the latest Node.js runtime for Cloud Functions."
│ ], badRequest
│
│   with module.coralogix_pubsub[0].google_cloudfunctions_function.this,
│   on .terraform/modules/coralogix_pubsub/modules/pubsub/main.tf line 44, in resource "google_cloudfunctions_function" "this":
│   44: resource "google_cloudfunctions_function" "this" {
│
╵
```